### PR TITLE
Fix outdated documentation link in multi-agent README

### DIFF
--- a/cookbooks/agents/multi-agent/README.md
+++ b/cookbooks/agents/multi-agent/README.md
@@ -19,7 +19,7 @@ For advanced observability and tracing features:
 pip install judgeval
 ```
 
-📖 **Learn more**: [Judgment Labs Documentation](https://docs.judgmentlabs.ai/quickstarts)
+📖 **Learn more**: [Judgment Labs Documentation](https://docs.judgmentlabs.ai/documentation)
 
 ### Set API Keys
 ```bash


### PR DESCRIPTION
This PR updates the documentation link in the README located at:

   judgment-cookbook/cookbooks/agents/multi-agent/README.md

The previously referenced URL led to a 404 error, preventing readers from accessing the correct guidance. I’ve replaced it with the current working link to the Judgment Labs documentation.

Changes Made:

    Replaced the old link https://docs.judgmentlabs.ai/quickstarts with the new link https://docs.judgmentlabs.ai/documentation in the “Quick Start” section.

Why This Matters:

    Prevents frustration from 404s or stale content.

    Ensures newcomers and contributors land on the right documentation the first time which improves onboarding flow.

    Reflects commitment to maintaining clear, accurate documentation.

